### PR TITLE
chore: migrate CODEOWNERS to new component team (26Q2)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,5 +2,5 @@
 # This file defines code owners for this repository
 
 # ============ Default Owners ============
-* @hardcoretech/scrum-shield
+* @hardcoretech/platform
 * @hardcoretech/backend

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,5 +2,4 @@
 # This file defines code owners for this repository
 
 # ============ Default Owners ============
-* @hardcoretech/platform
-* @hardcoretech/backend
+* @hardcoretech/platform @hardcoretech/backend


### PR DESCRIPTION
Auto-generated CODEOWNERS migration for 26Q2 team reorganization.

Replaces legacy scrum team references with the new component team assignment, or adds a catch-all if none existed.

See the org-level migration plan for full context.