### PR TITLE
chore(renovate): refresh config with explicit grouping + soak rules

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,15 +1,95 @@
 {
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
 
-  // Baseline = `hardcoretech/conf-renovate` (see preset README for the
-  // inherited policy: SHA-pinned GHA, 3-day release-age soak, OSV alerts,
-  // per-ecosystem grouping, major-update isolation, datastore version pinning).
-  // The preset auto-bumps this pin via its own customManager (v1.1.0+).
+  // Renovate baseline: SHA-pinned GHA, 3-day release-age soak, OSV
+  // vulnerability alerts, per-ecosystem grouping, major-update isolation.
+  // Python (poetry + pep621) + GHA only — this repo has no Docker / npm /
+  // terraform / datastore deps.
   extends: [
-    "github>hardcoretech/conf-renovate#v1.2.1",
-    // Don't widen semver ranges (`^1.2.3` stays `^1.2.3`). Not in the preset.
+    "config:best-practices",
+    // Don't widen semver ranges (`^1.2.3` stays `^1.2.3`).
     ":preserveSemverRanges",
   ],
 
   labels: ["dependencies"],
+
+  // ---- Volume controls ----
+  // Renovate has no `prWeeklyLimit`; the effective weekly cap is achieved by
+  // combining a weekly schedule with prConcurrentLimit + prHourlyLimit. Net
+  // effect: at most 4 PRs created per Monday and at most 4 open at any time.
+  prConcurrentLimit: 4,
+  prHourlyLimit: 4,
+  schedule: ["before 5am on monday"],
+  lockFileMaintenance: { enabled: true, schedule: ["before 5am on monday"] },
+  // Suppress PRs for deps that fail Renovate's internal status checks
+  // (upstream CI red, deprecation flagged, etc.). Reduces autoclose noise.
+  internalChecksFilter: "strict",
+
+  // ---- Security baseline ----
+  osvVulnerabilityAlerts: true,
+  vulnerabilityAlerts: {
+    enabled: true,
+    labels: ["security"],
+    // groupName:null is INTENTIONAL: security/CVE PRs must NEVER be batched
+    // with manager-grouping rules.
+    groupName: null,
+  },
+
+  packageRules: [
+    // Bundle lock file maintenance across all managers + sub-projects into ONE
+    // PR per cycle so a multi-lockfile repo doesn't exhaust prConcurrentLimit.
+    {
+      description: "Bundle lock file maintenance across all managers into one PR",
+      matchUpdateTypes: ["lockFileMaintenance"],
+      groupName: "lockfile-maintenance",
+    },
+
+    // ---- GHA SHA-pin + 3-day soak ----
+    // SHA pin protects against tag-mutation supply-chain attacks; the soak
+    // window gives the community time to surface CVEs before they hit our
+    // workflows.
+    {
+      description: "GitHub Actions: pin to SHA digests + enforce 3-day release soak",
+      matchManagers: ["github-actions"],
+      pinDigests: true,
+      minimumReleaseAge: "3 days",
+    },
+
+    // ---- Backend Python grouping ----
+    // `pep621` covers pyproject.toml [project] (uv / hatch / pdm); `poetry`
+    // covers [tool.poetry.dependencies]. A repo that uses only one still gets
+    // the same effective behaviour.
+    {
+      description: "Backend non-major (minor + patch) -> backend-non-major",
+      matchManagers: ["poetry", "pep621"],
+      matchUpdateTypes: ["minor", "patch"],
+      groupName: "backend-non-major",
+      minimumReleaseAge: "3 days",
+    },
+    {
+      // groupName:null is INTENTIONAL. Majors must never be batched — one
+      // stuck major blocks every other major in the group.
+      description: "Backend major -> isolated PR per dep (no group)",
+      matchManagers: ["poetry", "pep621"],
+      matchUpdateTypes: ["major"],
+      groupName: null,
+      minimumReleaseAge: "3 days",
+    },
+
+    // ---- GHA grouping ----
+    {
+      // 'digest' + 'pin' types included so that pinDigests:true SHA refreshes
+      // land in this group, not ungrouped.
+      description: "GHA non-major (minor, patch, digest, pin refreshes) -> gha-non-major",
+      matchManagers: ["github-actions"],
+      matchUpdateTypes: ["minor", "patch", "digest", "pin"],
+      groupName: "gha-non-major",
+    },
+    {
+      description: "GHA major -> isolated PR per action (no group)",
+      matchManagers: ["github-actions"],
+      matchUpdateTypes: ["major"],
+      groupName: null,
+    },
+  ],
 }


### PR DESCRIPTION
## Summary

Switch `renovate.json5` to an explicit, self-contained config. Resolves
the `Cannot find preset's package` validation error that was blocking
Renovate from opening PRs on this repo (see #28).

Same effective policy as before, just expressed locally:

- SHA-pinned GitHub Actions with `pinDigests: true`
- 3-day `minimumReleaseAge` soak on Python deps + GHA
- OSV vulnerability alerts (security PRs never batched)
- Per-ecosystem grouping (`backend-non-major`, `gha-non-major`)
- Major updates isolated to one PR per dep (`groupName: null`)
- Lockfile-maintenance bundled into one PR per cycle
- `prConcurrentLimit: 4` + `prHourlyLimit: 4` + Monday-only schedule

No behaviour change for the deps Renovate would have opened anyway — this
just makes the run actually succeed.

## Test plan

- [x] `renovate-config-validator --strict` passes locally
- [x] CI `pre-commit` passes on this PR

## Post-merge verification

Will confirm after merge:
- Renovate run on `main` succeeds (no config-validation issue re-opened)
- Renovate opens any pending grouped PR(s) — backend-non-major / gha-non-major

🤖 Generated with [Claude Code](https://claude.com/claude-code)